### PR TITLE
Add support to 2D array and multiple rows in one transform

### DIFF
--- a/src/XLSXRowTransform.js
+++ b/src/XLSXRowTransform.js
@@ -11,8 +11,14 @@ export default class XLSXRowTransform extends Transform {
      * Transform array to row string
      */
     _transform(row, encoding, callback) { // eslint-disable-line
-        const xlsxRow = Row(this.rowCount, row);
-        this.rowCount++;
+        let xlsxRow = '';
+        if (row[0] !== undefined && row[0].constructor === Array) { // check if 2d Array
+            for (let i = 0; i < row.length; i++) {
+                xlsxRow += Row(this.rowCount++, row[i]);
+            }
+        } else {
+            xlsxRow = Row(this.rowCount++, row);
+        }
         callback(null, xlsxRow);
     }
 }

--- a/src/XLSXRowTransform.js
+++ b/src/XLSXRowTransform.js
@@ -7,12 +7,17 @@ export default class XLSXRowTransform extends Transform {
         super({ objectMode: true });
         this.rowCount = 0;
     }
+
+    static is2DArray(arr) {
+        return (arr[0] !== undefined && arr[0].constructor === Array);
+    }
+
     /**
      * Transform array to row string
      */
     _transform(row, encoding, callback) { // eslint-disable-line
         let xlsxRow = '';
-        if (row[0] !== undefined && row[0].constructor === Array) { // check if 2d Array
+        if (XLSXRowTransform.is2DArray(row)) {
             for (let i = 0; i < row.length; i++) {
                 xlsxRow += Row(this.rowCount++, row[i]);
             }


### PR DESCRIPTION
This PR adds the support for 2D array as input. If a 2D array is passed in as the input, it will return multiple rows. 
This PR does not break the support for 1D array, which means it complies with the open-closed principle: any existing code that depends on this library does not need to change. 