### PR TITLE
Remove old prepublishOnly that blocks publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,7 @@
         "test-cov": "npm run build && babel-node node_modules/isparta/bin/isparta cover --report html --report text node_modules/.bin/_mocha",
         "prepare": "npm run build",
         "clean": "rm -rf dist",
-        "lint": "eslint src test",
-        "prepublishOnly": "(test $RUNNING_FROM_SCRIPT || (echo \"You must use publish.sh instead of 'npm publish' directly!\"; exit 1)) && npm test && npm run lint"
+        "lint": "eslint src test"
     },
     "dependencies": {
         "archiver": "^5.3.0",


### PR DESCRIPTION
prepublishOnly in package.json blocks publishing. It was used in the past with publish.sh, but now we use Github actions.