### PR TITLE
feature: add typings and build with typescript compiler

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,9 @@
         "lodash": "^4.17.4"
     },
     "devDependencies": {
+        "@apify/tsconfig": "^0.1.0",
         "rimraf": "^3.0.2",
+        "glob": "^7.2.0",
         "typescript": "^4.5.4",
         "apify-jsdoc-template": "github:apify/apify-jsdoc-template",
         "babel-cli": "^6.18.0",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "version": "1.0.0",
     "description": "XLSX stream writer",
     "main": "dist/index.js",
+    "typings": "dist/index.d.ts",
     "keywords": [
         "apify",
         "apifier",
@@ -31,11 +32,11 @@
     ],
     "scripts": {
         "start": "npm run build && node dist/index.js",
-        "build": "npm run clean && babel src --out-dir dist",
+        "build": "npm run clean && tsc",
         "test": "npm run build && mocha --require babel-core/register --recursive",
         "test-cov": "npm run build && babel-node node_modules/isparta/bin/isparta cover --report html --report text node_modules/.bin/_mocha",
         "prepare": "npm run build",
-        "clean": "rm -rf dist",
+        "clean": "rimraf dist",
         "lint": "eslint src test"
     },
     "dependencies": {
@@ -43,6 +44,8 @@
         "lodash": "^4.17.4"
     },
     "devDependencies": {
+        "rimraf": "^3.0.2",
+        "typescript": "^4.5.4",
         "apify-jsdoc-template": "github:apify/apify-jsdoc-template",
         "babel-cli": "^6.18.0",
         "babel-core": "^6.26.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "allowJs": true,
+        "declaration": true,
+        "outDir": "dist",
+        "target": "ES2018",
+    },
+    "exclude": [
+        "node_modules",
+        "build",
+        "dist"
+      ],
+    "include": [
+        "src/**/*"
+      ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,8 @@
 {
+    "extends": "@apify/tsconfig",
     "compilerOptions": {
-        "module": "commonjs",
-        "allowSyntheticDefaultImports": true,
-        "esModuleInterop": true,
         "allowJs": true,
-        "declaration": true,
         "outDir": "dist",
-        "target": "ES2018",
     },
     "exclude": [
         "node_modules",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,8 @@
 {
     "compilerOptions": {
         "module": "commonjs",
+        "allowSyntheticDefaultImports": true,
+        "esModuleInterop": true,
         "allowJs": true,
         "declaration": true,
         "outDir": "dist",


### PR DESCRIPTION
I needed typescript typings, so ended up using the typescript compiler to allow js and output sensible node compatible code.