### PR TITLE
Remove lodash dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,8 +40,7 @@
         "lint": "eslint src test"
     },
     "dependencies": {
-        "archiver": "^5.3.0",
-        "lodash": "^4.17.4"
+        "archiver": "^5.3.0"
     },
     "devDependencies": {
         "@apify/tsconfig": "^0.1.0",

--- a/src/templates/cell.js
+++ b/src/templates/cell.js
@@ -1,4 +1,3 @@
-import { isDate, isString, isNumber, isBoolean } from 'lodash';
 import { sanitize, getNumberFormat, getDateFormat } from '../utils';
 
 // 25569 = Days between 1970/01/01 and 1900/01/01 (min date in Windows Excel)
@@ -8,16 +7,16 @@ const OFFSET_DAYS = 25569;
 const MILLISECONDS_IN_ONE_DAY = 86400000;
 
 export default function (value, cell, shouldFormat) {
-    if (isDate(value)) {
+    if (value instanceof Date) {
         const unixTimestamp = value.getTime();
         const officeTimestamp = (unixTimestamp / MILLISECONDS_IN_ONE_DAY) + OFFSET_DAYS;
         const maybeFormat = shouldFormat && getDateFormat();
         return `<c r="${cell}" t="n"${maybeFormat ? ` s="${maybeFormat}"` : ''}><v>${officeTimestamp}</v></c>`;
-    } else if (isString(value)) {
+    } else if (typeof value === 'string') {
         return `<c r="${cell}" t="inlineStr"><is><t>${sanitize(value)}</t></is></c>`;
-    } else if (isBoolean(value)) {
+    } else if (typeof value === 'boolean') {
         return `<c r="${cell}" t="inlineStr"><is><t>${value}</t></is></c>`;
-    } else if (isNumber(value)) {
+    } else if (typeof value === 'number') {
         const maybeFormat = shouldFormat && getNumberFormat(value);
         return `<c r="${cell}" t="n"${maybeFormat ? ` s="${maybeFormat}"` : ''}><v>${value}</v></c>`;
     } else if (value) {


### PR DESCRIPTION
We know that `lodash` is a huge dependency and refuses to support tree shaking. And this library only uses a fraction of lodash for type checking. 

One improvement would be to only import the specific modules (i.e. `import isDate from 'lodash/isDate.js'`) not the entire lodash package.

However I feel that lodash is actually completely un-necessary in this case, and can be replaced with native type checks. Let me know your thoughts.