### PR TITLE
fix: add `tslib` to dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+1.0.3 / 2024-08-07
+==================
+- Add `tslib` to dependencies
+
+1.0.2 / 2024-05-18
+==================
+- Add `@types/node` to devDependencies to fix `.d.ts` files build
+
 1.0.1 / 2024-05-13
 ==================
 - Remove lodash dependency

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "xlsx-write-stream",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "description": "XLSX stream writer",
     "main": "dist/index.js",
     "typings": "dist/index.d.ts",
@@ -40,7 +40,8 @@
         "lint": "eslint src test"
     },
     "dependencies": {
-        "archiver": "^5.3.0"
+        "archiver": "^5.3.0",
+        "tslib": "^2.6.3"
     },
     "devDependencies": {
         "@apify/tsconfig": "^0.1.0",


### PR DESCRIPTION
This PR adds `tslib` to dependencies to fix runtime errors that have been reported.